### PR TITLE
Add missed blocks to proposer duties table

### DIFF
--- a/pkg/analyzer/process_state.go
+++ b/pkg/analyzer/process_state.go
@@ -129,10 +129,16 @@ loop:
 				// Proposer Duties
 
 				for _, item := range stateMetrics.GetMetricsBase().PrevState.EpochStructs.ProposerDuties {
-					newDuty := model.NewProposerDuties(uint64(item.ValidatorIndex), uint64(item.Slot))
+					newDuty := model.NewProposerDuties(uint64(item.ValidatorIndex), uint64(item.Slot), true)
+					for _, item := range missedBlocks {
+						if newDuty.ProposerSlot == item { // we found the proposer slot in the missed blocks
+							newDuty.Proposed = false
+						}
+					}
 					epochBatch.Queue(model.InsertProposerDuty,
 						newDuty.ValIdx,
-						newDuty.ProposerSlot)
+						newDuty.ProposerSlot,
+						newDuty.Proposed)
 				}
 			}
 

--- a/pkg/db/postgresql/model/proposer_duties.go
+++ b/pkg/db/postgresql/model/proposer_duties.go
@@ -6,13 +6,15 @@ var (
 	CREATE TABLE IF NOT EXISTS t_proposer_duties(
 		f_val_idx INT,
 		f_proposer_slot INT,
+		f_proposed BOOL,
 		CONSTRAINT PK_Val_Slot PRIMARY KEY (f_val_idx, f_proposer_slot));`
 
 	InsertProposerDuty = `
 	INSERT INTO t_proposer_duties (
 		f_val_idx, 
-		f_proposer_slot)
-		VALUES ($1, $2)
+		f_proposer_slot,
+		f_proposed)
+		VALUES ($1, $2, $3)
 		ON CONFLICT DO NOTHING;
 	`
 	// if there is a confilct the line already exists
@@ -21,15 +23,18 @@ var (
 type ProposerDuties struct {
 	ValIdx       uint64
 	ProposerSlot uint64
+	Proposed     bool
 }
 
 func NewProposerDuties(
 	iValIdx uint64,
-	iProposerSlot uint64) ProposerDuties {
+	iProposerSlot uint64,
+	iProposed bool) ProposerDuties {
 
 	return ProposerDuties{
 		ValIdx:       iValIdx,
 		ProposerSlot: iProposerSlot,
+		Proposed:     iProposed,
 	}
 }
 


### PR DESCRIPTION
# Motivation
Right now we store missed blocks in a string representing an array.
After having the proposer duties table to store which slot each validator proposes, it makes more sense to store here which block was missed, so as to be used in SQL queries.
The next task will be to clean the metrics stored, basically remove what is not used.

# TODOs
- Add a new field to proposer_duties table
- Check if block was missed and configure accordingly