### PR TITLE
Check finalized blocks in case the are missing

### DIFF
--- a/pkg/blocks/analyzer.go
+++ b/pkg/blocks/analyzer.go
@@ -46,6 +46,8 @@ type BlockAnalyzer struct {
 	routineClosed  chan struct{}
 	eventsObj      events.Events
 
+	HeadSlot uint64
+
 	initTime time.Time
 }
 
@@ -94,6 +96,7 @@ func NewBlockAnalyzer(
 		routineClosed:      make(chan struct{}),
 		eventsObj:          events.NewEventsObj(ctx, httpCli),
 		downloadMode:       downloadMode,
+		HeadSlot:           0,
 	}, nil
 }
 

--- a/pkg/blocks/process_block.go
+++ b/pkg/blocks/process_block.go
@@ -52,13 +52,15 @@ loop:
 				task.Block.ProposerIndex,
 				task.Proposed)
 
-			_, proposed, err := s.RequestBeaconBlock(int(task.Slot - FORK_CHOICE_SLOTS))
-			if !proposed && err == nil {
-				blockBatch.Queue(model.UpdateBlock,
-					task.Slot-FORK_CHOICE_SLOTS,
-					proposed)
-			}
+			if task.Slot > (s.HeadSlot - FORK_CHOICE_SLOTS) { // if we are close to head, then a correction might happen
 
+				_, proposed, err := s.RequestBeaconBlock(int(task.Slot - FORK_CHOICE_SLOTS))
+				if !proposed && err == nil {
+					blockBatch.Queue(model.UpdateBlock,
+						task.Slot-FORK_CHOICE_SLOTS,
+						proposed)
+				}
+			}
 			blockBatch.Queue(model.UpsertBlock,
 				blockMetrics.Epoch,
 				blockMetrics.Slot,

--- a/pkg/db/postgresql/model/block_metrics.go
+++ b/pkg/db/postgresql/model/block_metrics.go
@@ -33,8 +33,7 @@ var (
 
 	UPDATE t_block_metrics 
 	SET	f_proposed = $2
-	WHERE f_slot = $1
-	ON CONFLICT DO NOTHING;
+	WHERE f_slot = $1;
 	`
 	SelectLastSlot = `
 	SELECT f_slot

--- a/pkg/db/postgresql/model/block_metrics.go
+++ b/pkg/db/postgresql/model/block_metrics.go
@@ -29,6 +29,13 @@ var (
 				f_proposer_index = excluded.f_proposer_index,
 				f_proposed = excluded.f_proposed;
 	`
+	UpdateBlock = `
+
+	UPDATE t_block_metrics 
+	SET	f_proposed = $2
+	WHERE f_slot = $1
+	ON CONFLICT DO NOTHING;
+	`
 	SelectLastSlot = `
 	SELECT f_slot
 	FROM t_block_metrics


### PR DESCRIPTION
# Motivation
Blocks routine follows the chain at the head. It is possible that a block is published, but the reorg invalidates the given blocks (orphaned). Therefore, the head routine will also check x number of blocks behind, in case there is a missing that was not spotted because of being orphaned now.

# TODOs
- Check x number of slots behind for missing block
- If missing, update the blocks table