### PR TITLE
Add extra fields to standard block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOCC=go
 MKDIR_P=mkdir -p
 
 BIN_PATH=./build
-BIN="./build/eth2-state-analyzer"
+BIN="./build/eth-cl-state-analyzer"
 
 
 

--- a/pkg/block_metrics/fork_block/altair.go
+++ b/pkg/block_metrics/fork_block/altair.go
@@ -2,14 +2,29 @@ package fork_block
 
 import (
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
 func NewAltairBlock(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase {
 	return ForkBlockContentBase{
-		Slot:          uint64(block.Altair.Message.Slot),
-		ProposerIndex: uint64(block.Altair.Message.ProposerIndex),
-		Graffiti:      block.Altair.Message.Body.Graffiti,
-		Attestations:  block.Altair.Message.Body.Attestations,
-		Deposits:      block.Altair.Message.Body.Deposits,
+		Slot:              uint64(block.Altair.Message.Slot),
+		ProposerIndex:     uint64(block.Altair.Message.ProposerIndex),
+		Graffiti:          block.Altair.Message.Body.Graffiti,
+		Attestations:      block.Altair.Message.Body.Attestations,
+		Deposits:          block.Altair.Message.Body.Deposits,
+		ProposerSlashings: block.Altair.Message.Body.ProposerSlashings,
+		AttesterSlashings: block.Altair.Message.Body.AttesterSlashings,
+		VoluntaryExits:    block.Altair.Message.Body.VoluntaryExits,
+		SyncAggregate:     block.Altair.Message.Body.SyncAggregate,
+		ExecutionPayload: ForkBlockPayloadBase{
+			FeeRecipient:  bellatrix.ExecutionAddress{},
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			BaseFeePerGas: [32]byte{},
+			BlockHash:     phase0.Hash32{},
+			Transactions:  make([]bellatrix.Transaction, 0),
+		},
 	}
 }

--- a/pkg/block_metrics/fork_block/bellatrix.go
+++ b/pkg/block_metrics/fork_block/bellatrix.go
@@ -1,13 +1,28 @@
 package fork_block
 
-import "github.com/attestantio/go-eth2-client/spec"
+import (
+	"github.com/attestantio/go-eth2-client/spec"
+)
 
 func NewBellatrixBlock(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase {
 	return ForkBlockContentBase{
-		Slot:          uint64(block.Bellatrix.Message.Slot),
-		ProposerIndex: uint64(block.Bellatrix.Message.ProposerIndex),
-		Graffiti:      block.Bellatrix.Message.Body.Graffiti,
-		Attestations:  block.Bellatrix.Message.Body.Attestations,
-		Deposits:      block.Bellatrix.Message.Body.Deposits,
+		Slot:              uint64(block.Bellatrix.Message.Slot),
+		ProposerIndex:     uint64(block.Bellatrix.Message.ProposerIndex),
+		Graffiti:          block.Bellatrix.Message.Body.Graffiti,
+		Attestations:      block.Bellatrix.Message.Body.Attestations,
+		Deposits:          block.Bellatrix.Message.Body.Deposits,
+		ProposerSlashings: block.Bellatrix.Message.Body.ProposerSlashings,
+		AttesterSlashings: block.Bellatrix.Message.Body.AttesterSlashings,
+		VoluntaryExits:    block.Bellatrix.Message.Body.VoluntaryExits,
+		SyncAggregate:     block.Bellatrix.Message.Body.SyncAggregate,
+		ExecutionPayload: ForkBlockPayloadBase{
+			FeeRecipient:  block.Bellatrix.Message.Body.ExecutionPayload.FeeRecipient,
+			GasLimit:      block.Bellatrix.Message.Body.ExecutionPayload.GasLimit,
+			GasUsed:       block.Bellatrix.Message.Body.ExecutionPayload.GasUsed,
+			Timestamp:     block.Bellatrix.Message.Body.ExecutionPayload.Timestamp,
+			BaseFeePerGas: block.Bellatrix.Message.Body.ExecutionPayload.BaseFeePerGas,
+			BlockHash:     block.Bellatrix.Message.Body.ExecutionPayload.BlockHash,
+			Transactions:  block.Bellatrix.Message.Body.ExecutionPayload.Transactions,
+		},
 	}
 }

--- a/pkg/block_metrics/fork_block/phase0.go
+++ b/pkg/block_metrics/fork_block/phase0.go
@@ -2,14 +2,30 @@ package fork_block
 
 import (
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
 func NewPhase0Block(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase {
 	return ForkBlockContentBase{
-		Slot:          uint64(block.Phase0.Message.Slot),
-		ProposerIndex: uint64(block.Phase0.Message.ProposerIndex),
-		Graffiti:      block.Phase0.Message.Body.Graffiti,
-		Attestations:  block.Phase0.Message.Body.Attestations,
-		Deposits:      block.Phase0.Message.Body.Deposits,
+		Slot:              uint64(block.Phase0.Message.Slot),
+		ProposerIndex:     uint64(block.Phase0.Message.ProposerIndex),
+		Graffiti:          block.Phase0.Message.Body.Graffiti,
+		Attestations:      block.Phase0.Message.Body.Attestations,
+		Deposits:          block.Phase0.Message.Body.Deposits,
+		ProposerSlashings: block.Phase0.Message.Body.ProposerSlashings,
+		AttesterSlashings: block.Phase0.Message.Body.AttesterSlashings,
+		VoluntaryExits:    block.Phase0.Message.Body.VoluntaryExits,
+		SyncAggregate:     &altair.SyncAggregate{},
+		ExecutionPayload: ForkBlockPayloadBase{
+			FeeRecipient:  bellatrix.ExecutionAddress{},
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			BaseFeePerGas: [32]byte{},
+			BlockHash:     phase0.Hash32{},
+			Transactions:  make([]bellatrix.Transaction, 0),
+		},
 	}
 }

--- a/pkg/block_metrics/fork_block/standard.go
+++ b/pkg/block_metrics/fork_block/standard.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 )
@@ -20,8 +22,13 @@ type ForkBlockContentBase struct {
 	ProposerIndex uint64
 	Graffiti      [32]byte
 
-	Attestations []*phase0.Attestation
-	Deposits     []*phase0.Deposit
+	Attestations      []*phase0.Attestation
+	Deposits          []*phase0.Deposit
+	ProposerSlashings []*phase0.ProposerSlashing
+	AttesterSlashings []*phase0.AttesterSlashing
+	VoluntaryExits    []*phase0.SignedVoluntaryExit
+	SyncAggregate     *altair.SyncAggregate
+	ExecutionPayload  ForkBlockPayloadBase
 }
 
 func GetCustomBlock(block spec.VersionedSignedBeaconBlock) (ForkBlockContentBase, error) {
@@ -38,4 +45,15 @@ func GetCustomBlock(block spec.VersionedSignedBeaconBlock) (ForkBlockContentBase
 	default:
 		return ForkBlockContentBase{}, fmt.Errorf("could not figure out the Beacon Block Fork Version: %s", block.Version)
 	}
+}
+
+// This Wrapper is meant to include all common objects across Ethereum Hard Fork Specs
+type ForkBlockPayloadBase struct {
+	FeeRecipient  bellatrix.ExecutionAddress
+	GasLimit      uint64
+	GasUsed       uint64
+	Timestamp     uint64
+	BaseFeePerGas [32]byte
+	BlockHash     phase0.Hash32
+	Transactions  []bellatrix.Transaction
 }

--- a/pkg/blocks/analyzer.go
+++ b/pkg/blocks/analyzer.go
@@ -5,12 +5,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/block_metrics/fork_block"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/clientapi"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/db/postgresql"
 	"github.com/cortze/eth-cl-state-analyzer/pkg/events"
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/sirupsen/logrus"
 )
 
@@ -176,10 +179,25 @@ func (s BlockAnalyzer) CreateMissingBlock(slot int) fork_block.ForkBlockContentB
 	}
 
 	return fork_block.ForkBlockContentBase{
-		Slot:          uint64(slot),
-		ProposerIndex: uint64(proposerValIdx),
-		Graffiti:      [32]byte{},
-		Attestations:  nil,
-		Deposits:      nil,
+		Slot:              uint64(slot),
+		ProposerIndex:     uint64(proposerValIdx),
+		Graffiti:          [32]byte{},
+		Attestations:      make([]*phase0.Attestation, 0),
+		Deposits:          make([]*phase0.Deposit, 0),
+		ProposerSlashings: make([]*phase0.ProposerSlashing, 0),
+		AttesterSlashings: make([]*phase0.AttesterSlashing, 0),
+		VoluntaryExits:    make([]*phase0.SignedVoluntaryExit, 0),
+		SyncAggregate: &altair.SyncAggregate{
+			SyncCommitteeBits:      bitfield.NewBitvector512(),
+			SyncCommitteeSignature: phase0.BLSSignature{}},
+		ExecutionPayload: fork_block.ForkBlockPayloadBase{
+			FeeRecipient:  bellatrix.ExecutionAddress{},
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			BaseFeePerGas: [32]byte{},
+			BlockHash:     phase0.Hash32{},
+			Transactions:  make([]bellatrix.Transaction, 0),
+		},
 	}
 }

--- a/pkg/blocks/process_block.go
+++ b/pkg/blocks/process_block.go
@@ -46,14 +46,38 @@ loop:
 				task.Slot,
 				task.Block.Graffiti,
 				task.Block.ProposerIndex,
-				task.Proposed)
+				task.Proposed,
+				task.Block.Attestations,
+				task.Block.Deposits,
+				task.Block.ProposerSlashings,
+				task.Block.AttesterSlashings,
+				task.Block.VoluntaryExits,
+				task.Block.SyncAggregate,
+				task.Block.ExecutionPayload.FeeRecipient,
+				task.Block.ExecutionPayload.GasLimit,
+				task.Block.ExecutionPayload.GasUsed,
+				task.Block.ExecutionPayload.BaseFeePerGas,
+				task.Block.ExecutionPayload.BlockHash,
+				task.Block.ExecutionPayload.Transactions)
 
 			blockBatch.Queue(model.UpsertBlock,
 				blockMetrics.Epoch,
 				blockMetrics.Slot,
 				blockMetrics.Graffiti,
 				blockMetrics.ProposerIndex,
-				blockMetrics.Proposed)
+				blockMetrics.Proposed,
+				blockMetrics.Attestatons,
+				blockMetrics.Deposits,
+				blockMetrics.ProposerSlashings,
+				blockMetrics.AttSlashings,
+				blockMetrics.VoluntaryExits,
+				blockMetrics.SyncBits,
+				blockMetrics.ELFeeRecp,
+				blockMetrics.ELGasLimit,
+				blockMetrics.ELGasUsed,
+				blockMetrics.ELBaseFeePerGas,
+				blockMetrics.ELBlockHash,
+				blockMetrics.ELTransactions)
 			// Flush the database batches
 			if blockBatch.Len() >= postgresql.MAX_EPOCH_BATCH_QUEUE {
 				s.dbClient.WriteChan <- blockBatch

--- a/pkg/blocks/process_block.go
+++ b/pkg/blocks/process_block.go
@@ -42,6 +42,7 @@ loop:
 			log.Infof("block task received for slot %d, analyzing...", task.Slot)
 
 			blockMetrics := model.NewBlockMetrics(
+				task.Block.ExecutionPayload.Timestamp,
 				task.Slot/uint64(EPOCH_SLOTS),
 				task.Slot,
 				task.Block.Graffiti,
@@ -61,6 +62,7 @@ loop:
 				task.Block.ExecutionPayload.Transactions)
 
 			blockBatch.Queue(model.UpsertBlock,
+				blockMetrics.ELTimestamp,
 				blockMetrics.Epoch,
 				blockMetrics.Slot,
 				blockMetrics.Graffiti,

--- a/pkg/db/postgresql/model/block_metrics.go
+++ b/pkg/db/postgresql/model/block_metrics.go
@@ -1,6 +1,13 @@
 package model
 
-import "strings"
+import (
+	"encoding/binary"
+	"strings"
+
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
 
 // Postgres intregration variables
 var (
@@ -75,27 +82,63 @@ var (
 )
 
 type BlockMetrics struct {
-	Epoch         uint64
-	Slot          uint64
-	Graffiti      string
-	ProposerIndex uint64
-	Proposed      bool
+	Epoch             uint64
+	Slot              uint64
+	Graffiti          string
+	ProposerIndex     uint64
+	Proposed          bool
+	Attestatons       uint64
+	Deposits          uint64
+	ProposerSlashings uint64
+	AttSlashings      uint64
+	VoluntaryExits    uint64
+	SyncBits          uint64
+	ELFeeRecp         string
+	ELGasLimit        uint64
+	ELGasUsed         uint64
+	ELBaseFeePerGas   uint64
+	ELBlockHash       string
+	ELTransactions    uint64
 }
 
 func NewBlockMetrics(iEpoch uint64,
 	iSlot uint64,
 	iGraffiti [32]byte,
 	iProposerIndex uint64,
-	iProposed bool) BlockMetrics {
+	iProposed bool,
+	iAttestatons []*phase0.Attestation,
+	iDeposits []*phase0.Deposit,
+	iProposerSlashings []*phase0.ProposerSlashing,
+	iAttSlashings []*phase0.AttesterSlashing,
+	iVoluntaryExits []*phase0.SignedVoluntaryExit,
+	iSyncBits *altair.SyncAggregate,
+	iELFeeRecp bellatrix.ExecutionAddress,
+	iELGasLimit uint64,
+	iELGasUsed uint64,
+	iELBaseFeePerGas [32]byte,
+	iELBlockHash phase0.Hash32,
+	iELTransactions []bellatrix.Transaction) BlockMetrics {
 
 	graffiti := strings.ReplaceAll(string(iGraffiti[:]), "\u0000", "")
 
 	return BlockMetrics{
-		Epoch:         iEpoch,
-		Slot:          iSlot,
-		Graffiti:      graffiti,
-		ProposerIndex: iProposerIndex,
-		Proposed:      iProposed,
+		Epoch:             iEpoch,
+		Slot:              iSlot,
+		Graffiti:          graffiti,
+		ProposerIndex:     iProposerIndex,
+		Proposed:          iProposed,
+		Attestatons:       uint64(len(iAttestatons)),
+		Deposits:          uint64(len(iDeposits)),
+		ProposerSlashings: uint64(len(iProposerSlashings)),
+		AttSlashings:      uint64(len(iAttSlashings)),
+		VoluntaryExits:    uint64(len(iVoluntaryExits)),
+		SyncBits:          iSyncBits.SyncCommitteeBits.Count(),
+		ELFeeRecp:         iELFeeRecp.String(),
+		ELGasLimit:        iELGasLimit,
+		ELGasUsed:         iELGasUsed,
+		ELBaseFeePerGas:   uint64(binary.BigEndian.Uint64(iELBaseFeePerGas[:])),
+		ELBlockHash:       iELBlockHash.String(),
+		ELTransactions:    uint64(len(iELTransactions)),
 	}
 }
 

--- a/pkg/db/postgresql/model/block_metrics.go
+++ b/pkg/db/postgresql/model/block_metrics.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"encoding/binary"
 	"strings"
 
 	"github.com/attestantio/go-eth2-client/spec/altair"
@@ -82,6 +81,7 @@ var (
 )
 
 type BlockMetrics struct {
+	ELTimestamp       uint64
 	Epoch             uint64
 	Slot              uint64
 	Graffiti          string
@@ -101,7 +101,9 @@ type BlockMetrics struct {
 	ELTransactions    uint64
 }
 
-func NewBlockMetrics(iEpoch uint64,
+func NewBlockMetrics(
+	iELTimeStamp uint64,
+	iEpoch uint64,
 	iSlot uint64,
 	iGraffiti [32]byte,
 	iProposerIndex uint64,
@@ -122,6 +124,7 @@ func NewBlockMetrics(iEpoch uint64,
 	graffiti := strings.ReplaceAll(string(iGraffiti[:]), "\u0000", "")
 
 	return BlockMetrics{
+		ELTimestamp:       iELTimeStamp,
 		Epoch:             iEpoch,
 		Slot:              iSlot,
 		Graffiti:          graffiti,
@@ -136,7 +139,7 @@ func NewBlockMetrics(iEpoch uint64,
 		ELFeeRecp:         iELFeeRecp.String(),
 		ELGasLimit:        iELGasLimit,
 		ELGasUsed:         iELGasUsed,
-		ELBaseFeePerGas:   uint64(binary.BigEndian.Uint64(iELBaseFeePerGas[:])),
+		ELBaseFeePerGas:   0,
 		ELBlockHash:       iELBlockHash.String(),
 		ELTransactions:    uint64(len(iELTransactions)),
 	}

--- a/pkg/db/postgresql/model/block_metrics.go
+++ b/pkg/db/postgresql/model/block_metrics.go
@@ -6,28 +6,66 @@ import "strings"
 var (
 	CreateBlockMetricsTable = `
 	CREATE TABLE IF NOT EXISTS t_block_metrics(
+		f_timestamp INT,
 		f_epoch INT,
 		f_slot INT,
 		f_graffiti TEXT,
 		f_proposer_index INT,
 		f_proposed BOOL,
+		f_attestations INT,
+		f_deposits INT,
+		f_proposer_slashings INT,
+		f_att_slashings INT,
+		f_voluntary_exits INT,
+		f_sync_bits INT,
+		f_el_fee_recp TEXT,
+		f_el_gas_limit INT,
+		f_el_gas_used INT,
+		f_el_base_fee_per_gas INT,
+		f_el_block_hash TEXT,
+		f_el_transactions INT,
 		CONSTRAINT PK_Slot PRIMARY KEY (f_slot));`
 
 	UpsertBlock = `
 	INSERT INTO t_block_metrics (
+		f_timestamp,
 		f_epoch, 
 		f_slot,
 		f_graffiti,
 		f_proposer_index,
-		f_proposed)
-		VALUES ($1, $2, $3, $4, $5)
+		f_proposed,
+		f_attestations,
+		f_deposits,
+		f_proposer_slashings,
+		f_att_slashings,
+		f_voluntary_exits,
+		f_sync_bits,
+		f_el_fee_recp,
+		f_el_gas_limit,
+		f_el_gas_used,
+		f_el_base_fee_per_gas,
+		f_el_block_hash,
+		f_el_transactions)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
 		ON CONFLICT ON CONSTRAINT PK_Slot
 		DO
 			UPDATE SET
 				f_epoch = excluded.f_epoch,
 				f_graffiti = excluded.f_graffiti,
 				f_proposer_index = excluded.f_proposer_index,
-				f_proposed = excluded.f_proposed;
+				f_proposed = excluded.f_proposed,
+				f_attestations = excluded.f_attestations,
+				f_deposits = excluded.f_deposits,
+				f_proposer_slashings = excluded.f_proposer_slashings,
+				f_att_slashings = excluded.f_att_slashings,
+				f_voluntary_exits = excluded.f_voluntary_exits,
+				f_sync_bits = excluded.f_sync_bits,
+				f_el_fee_recp = excluded.f_el_fee_recp,
+				f_el_gas_limit = excluded.f_el_gas_limit,
+				f_el_gas_used = excluded.f_el_gas_used,
+				f_el_base_fee_per_gas = excluded.f_el_base_fee_per_gas,
+				f_el_block_hash = excluded.f_el_block_hash,
+				f_el_transactions = excluded.f_el_transactions;
 	`
 	SelectLastSlot = `
 	SELECT f_slot


### PR DESCRIPTION
# Motivation
After a stable version of the tool and blocks download, we now aim to add more metrics to the block metrics.

# TODOs
- Check which fields can be extracted from SignedBeaconBlock
- Extract for all forks (Phase0, Altair, Bellatrix)
- Add fields to database (reorganize tables if needed)
- Store new metrics in database