### PR TITLE
Add Att Slot to database

### DIFF
--- a/pkg/db/postgresql/model/validator_rewards.go
+++ b/pkg/db/postgresql/model/validator_rewards.go
@@ -33,13 +33,14 @@ var (
 		f_max_reward,
 		f_max_att_reward,
 		f_max_sync_reward,
+		f_att_slot,
 		f_base_reward,
 		f_in_sync_committee,
 		f_missing_source,
 		f_missing_target,
 		f_missing_head,
 		f_status)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 	ON CONFLICT ON CONSTRAINT PK_ValidatorSlot
 		DO 
 			UPDATE SET 
@@ -47,6 +48,7 @@ var (
 				f_balance_eth = excluded.f_balance_eth,
 				f_reward = excluded.f_reward,
 				f_max_reward = excluded.f_max_reward,
+				f_att_slot = excluded.f_att_slot,
 				f_base_reward = excluded.f_base_reward,
 				f_in_sync_committee = excluded.f_in_sync_committee,
 				f_missing_source = excluded.f_missing_source,

--- a/pkg/state/validatorWorker.go
+++ b/pkg/state/validatorWorker.go
@@ -103,6 +103,7 @@ loop:
 						validatorDBRow.MaxReward,
 						validatorDBRow.AttestationReward,
 						validatorDBRow.SyncCommitteeReward,
+						validatorDBRow.AttSlot,
 						validatorDBRow.BaseReward,
 						validatorDBRow.InSyncCommittee,
 						validatorDBRow.MissingSource,


### PR DESCRIPTION
# Motivation
There is one field we are not filling inside the database and we have already calculated: Attestation Slot
This is the slot that the validator had to attest to.

#TODOs:
- Persist to database