### PR TITLE
Feature/capella fork

### DIFF
--- a/pkg/block_metrics/fork_block/altair.go
+++ b/pkg/block_metrics/fork_block/altair.go
@@ -3,6 +3,7 @@ package fork_block
 import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
@@ -26,6 +27,7 @@ func NewAltairBlock(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase 
 			BlockHash:     phase0.Hash32{},
 			Transactions:  make([]bellatrix.Transaction, 0),
 			BlockNumber:   0,
+			Withdrawals:   make([]*capella.Withdrawal, 0),
 		},
 	}
 }

--- a/pkg/block_metrics/fork_block/bellatrix.go
+++ b/pkg/block_metrics/fork_block/bellatrix.go
@@ -2,6 +2,7 @@ package fork_block
 
 import (
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 )
 
 func NewBellatrixBlock(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase {
@@ -24,6 +25,7 @@ func NewBellatrixBlock(block spec.VersionedSignedBeaconBlock) ForkBlockContentBa
 			BlockHash:     block.Bellatrix.Message.Body.ExecutionPayload.BlockHash,
 			Transactions:  block.Bellatrix.Message.Body.ExecutionPayload.Transactions,
 			BlockNumber:   block.Bellatrix.Message.Body.ExecutionPayload.BlockNumber,
+			Withdrawals:   make([]*capella.Withdrawal, 0),
 		},
 	}
 }

--- a/pkg/block_metrics/fork_block/capella.go
+++ b/pkg/block_metrics/fork_block/capella.go
@@ -1,0 +1,29 @@
+package fork_block
+
+import (
+	"github.com/attestantio/go-eth2-client/spec"
+)
+
+func NewCapellaBlock(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase {
+	return ForkBlockContentBase{
+		Slot:              uint64(block.Capella.Message.Slot),
+		ProposerIndex:     uint64(block.Capella.Message.ProposerIndex),
+		Graffiti:          block.Capella.Message.Body.Graffiti,
+		Attestations:      block.Capella.Message.Body.Attestations,
+		Deposits:          block.Capella.Message.Body.Deposits,
+		ProposerSlashings: block.Capella.Message.Body.ProposerSlashings,
+		AttesterSlashings: block.Capella.Message.Body.AttesterSlashings,
+		VoluntaryExits:    block.Capella.Message.Body.VoluntaryExits,
+		SyncAggregate:     block.Capella.Message.Body.SyncAggregate,
+		ExecutionPayload: ForkBlockPayloadBase{
+			FeeRecipient:  block.Capella.Message.Body.ExecutionPayload.FeeRecipient,
+			GasLimit:      block.Capella.Message.Body.ExecutionPayload.GasLimit,
+			GasUsed:       block.Capella.Message.Body.ExecutionPayload.GasUsed,
+			Timestamp:     block.Capella.Message.Body.ExecutionPayload.Timestamp,
+			BaseFeePerGas: block.Capella.Message.Body.ExecutionPayload.BaseFeePerGas,
+			BlockHash:     block.Capella.Message.Body.ExecutionPayload.BlockHash,
+			Transactions:  block.Capella.Message.Body.ExecutionPayload.Transactions,
+			BlockNumber:   block.Capella.Message.Body.ExecutionPayload.BlockNumber,
+		},
+	}
+}

--- a/pkg/block_metrics/fork_block/capella.go
+++ b/pkg/block_metrics/fork_block/capella.go
@@ -24,6 +24,7 @@ func NewCapellaBlock(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase
 			BlockHash:     block.Capella.Message.Body.ExecutionPayload.BlockHash,
 			Transactions:  block.Capella.Message.Body.ExecutionPayload.Transactions,
 			BlockNumber:   block.Capella.Message.Body.ExecutionPayload.BlockNumber,
+			Withdrawals:   block.Capella.Message.Body.ExecutionPayload.Withdrawals,
 		},
 	}
 }

--- a/pkg/block_metrics/fork_block/phase0.go
+++ b/pkg/block_metrics/fork_block/phase0.go
@@ -4,6 +4,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
@@ -27,6 +28,7 @@ func NewPhase0Block(block spec.VersionedSignedBeaconBlock) ForkBlockContentBase 
 			BlockHash:     phase0.Hash32{},
 			Transactions:  make([]bellatrix.Transaction, 0),
 			BlockNumber:   0,
+			Withdrawals:   make([]*capella.Withdrawal, 0),
 		},
 	}
 }

--- a/pkg/block_metrics/fork_block/standard.go
+++ b/pkg/block_metrics/fork_block/standard.go
@@ -6,6 +6,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/sirupsen/logrus"
 )
@@ -59,4 +60,5 @@ type ForkBlockPayloadBase struct {
 	BlockHash     phase0.Hash32
 	Transactions  []bellatrix.Transaction
 	BlockNumber   uint64
+	Withdrawals   []*capella.Withdrawal
 }

--- a/pkg/block_metrics/fork_block/standard.go
+++ b/pkg/block_metrics/fork_block/standard.go
@@ -42,6 +42,8 @@ func GetCustomBlock(block spec.VersionedSignedBeaconBlock) (ForkBlockContentBase
 
 	case spec.DataVersionBellatrix:
 		return NewBellatrixBlock(block), nil
+	case spec.DataVersionCapella:
+		return NewCapellaBlock(block), nil
 	default:
 		return ForkBlockContentBase{}, fmt.Errorf("could not figure out the Beacon Block Fork Version: %s", block.Version)
 	}

--- a/pkg/blocks/process_block.go
+++ b/pkg/blocks/process_block.go
@@ -82,6 +82,15 @@ loop:
 				blockMetrics.ELBlockHash,
 				blockMetrics.ELTransactions,
 				blockMetrics.BlockNumber)
+
+			for _, item := range task.Block.ExecutionPayload.Withdrawals {
+				blockBatch.Queue(model.UpsertWithdrawal,
+					blockMetrics.Slot,
+					item.Index,
+					item.ValidatorIndex,
+					item.Address,
+					item.Amount)
+			}
 			// Flush the database batches
 			if blockBatch.Len() >= postgresql.MAX_EPOCH_BATCH_QUEUE {
 				s.dbClient.WriteChan <- blockBatch

--- a/pkg/db/postgresql/model/validator_rewards.go
+++ b/pkg/db/postgresql/model/validator_rewards.go
@@ -10,7 +10,7 @@ var (
 		f_slot INT,
 		f_epoch INT,
 		f_balance_eth REAL,
-		f_reward INT,
+		f_reward BIGINT,
 		f_max_reward INT,
 		f_max_att_reward INT,
 		f_max_sync_reward INT,

--- a/pkg/db/postgresql/model/withdrawals.go
+++ b/pkg/db/postgresql/model/withdrawals.go
@@ -1,0 +1,29 @@
+package model
+
+// Postgres intregration variables
+var (
+	CreateWithdrawalsTable = `
+	CREATE TABLE IF NOT EXISTS t_withdrawals(
+		f_slot INT,
+		f_index INT,
+		f_val_idx INT,
+		f_address TEXT,
+		f_amount BIGINT,
+		CONSTRAINT PK_Withdrawal PRIMARY KEY (f_slot, f_index));`
+
+	UpsertWithdrawal = `
+	INSERT INTO t_withdrawals (
+		f_slot,
+		f_index, 
+		f_val_idx,
+		f_address,
+		f_amount)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT ON CONSTRAINT PK_Withdrawal
+		DO
+		UPDATE SET 
+			f_val_idx = excluded.f_val_idx,
+			f_address = excluded.f_address,
+			f_amount = excluded.f_amount;
+	`
+)

--- a/pkg/db/postgresql/service.go
+++ b/pkg/db/postgresql/service.go
@@ -113,6 +113,11 @@ func (p *PostgresDBService) init(ctx context.Context, pool *pgxpool.Pool) error 
 		return err
 	}
 
+	err = p.createWithdrawalsTable()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/db/postgresql/withdrawals.go
+++ b/pkg/db/postgresql/withdrawals.go
@@ -1,0 +1,15 @@
+package postgresql
+
+import (
+	"github.com/cortze/eth-cl-state-analyzer/pkg/db/postgresql/model"
+	"github.com/pkg/errors"
+)
+
+func (p *PostgresDBService) createWithdrawalsTable() error {
+	// create the tables
+	_, err := p.psqlPool.Exec(p.ctx, model.CreateWithdrawalsTable)
+	if err != nil {
+		return errors.Wrap(err, "error creating withdrawals table")
+	}
+	return nil
+}

--- a/pkg/state/download_state.go
+++ b/pkg/state/download_state.go
@@ -84,6 +84,11 @@ func (s *StateAnalyzer) runDownloadStatesFinalized(wgDownload *sync.WaitGroup) {
 				log.Errorf("error downloading state at slot %d", slot, err)
 				continue
 			}
+			if s.finishDownload {
+				log.Info("sudden shutdown detected, state downloader routine")
+				close(s.EpochTaskChan)
+				return
+			}
 		}
 
 	}

--- a/pkg/state_metrics/fork_state/capella.go
+++ b/pkg/state_metrics/fork_state/capella.go
@@ -1,0 +1,28 @@
+package fork_state
+
+import (
+	"github.com/attestantio/go-eth2-client/http"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/cortze/eth-cl-state-analyzer/pkg/utils"
+)
+
+// This Wrapper is meant to include all necessary data from the Capella Fork
+func NewCapellaState(bstate spec.VersionedBeaconState, iApi *http.Service) ForkStateContentBase {
+
+	capellaObj := ForkStateContentBase{
+		Version:       bstate.Version,
+		Balances:      GweiToUint64(bstate.Capella.Balances),
+		Validators:    bstate.Capella.Validators,
+		EpochStructs:  NewEpochData(iApi, uint64(bstate.Capella.Slot)),
+		Epoch:         utils.GetEpochFromSlot(uint64(bstate.Capella.Slot)),
+		Slot:          uint64(bstate.Capella.Slot),
+		BlockRoots:    RootToByte(bstate.Capella.BlockRoots),
+		SyncCommittee: *bstate.Capella.CurrentSyncCommittee,
+	}
+
+	capellaObj.Setup()
+
+	ProcessAttestations(&capellaObj, bstate.Capella.PreviousEpochParticipation)
+
+	return capellaObj
+}

--- a/pkg/state_metrics/fork_state/standard.go
+++ b/pkg/state_metrics/fork_state/standard.go
@@ -56,6 +56,9 @@ func GetCustomState(bstate spec.VersionedBeaconState, iApi *http.Service) (ForkS
 
 	case spec.DataVersionBellatrix:
 		return NewBellatrixState(bstate, iApi), nil
+
+	case spec.DataVersionCapella:
+		return NewCapellaState(bstate, iApi), nil
 	default:
 		return ForkStateContentBase{}, fmt.Errorf("could not figure out the Beacon State Fork Version: %s", bstate.Version)
 	}

--- a/pkg/state_metrics/standard.go
+++ b/pkg/state_metrics/standard.go
@@ -56,8 +56,11 @@ func StateMetricsByForkVersion(nextBstate fork_state.ForkStateContentBase, bstat
 
 	case spec.DataVersionBellatrix:
 		return NewAltairMetrics(nextBstate, bstate, prevBstate), nil // We use Altair as Rewards system is the same
+
+	case spec.DataVersionCapella:
+		return NewAltairMetrics(nextBstate, bstate, prevBstate), nil // We use Altair as Rewards system is the same
 	default:
-		return nil, fmt.Errorf("could not figure out the Beacon State Fork Version: %s", bstate.Version)
+		return nil, fmt.Errorf("could not figure out the State Metrics Fork Version: %s", bstate.Version)
 	}
 }
 


### PR DESCRIPTION
# Description
The Ethereum chain gets upgraded every certain amount of time. This is done through forks and, thus, it is needed to implement the changes to support the new data structures. This time, Capella has recently happened in the Goerli network and will soon happen in mainnet. With this PR, our intention is to support the new Capella fork changes.

# Changes
- Support Capella fork Beacon Blocks
- Add Withdrawals to Beacon Block metrics and persist them into a separate table
- Support Capella Beacon States
- Change Reward column in Validator table to bigint, as withdrawals could cause a big negative reward (balance change)

